### PR TITLE
Ported OpenMW's "Don't use unordered_map" commit changes to TES3MP to fix #1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,12 +209,6 @@ if(NOT HAVE_STDINT_H)
     message(FATAL_ERROR "stdint.h was not found" )
 endif()
 
-include (CheckIncludeFileCXX)
-check_include_file_cxx(unordered_map HAVE_UNORDERED_MAP)
-if (HAVE_UNORDERED_MAP)
-    add_definitions(-DHAVE_UNORDERED_MAP)
-endif ()
-
 
 set(BOOST_COMPONENTS system filesystem program_options thread)
 if(WIN32)

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1,13 +1,5 @@
 #include "worldimp.hpp"
 
-#if defined(_WIN32) && !defined(__MINGW32__)
-#include <boost/tr1/tr1/unordered_map>
-#elif defined HAVE_UNORDERED_MAP
-#include <unordered_map>
-#else
-#include <tr1/unordered_map>
-#endif
-
 #include <osg/Group>
 #include <osg/ComputeBoundsVisitor>
 
@@ -108,7 +100,7 @@ namespace MWWorld
         }
 
         private:
-          typedef std::tr1::unordered_map<std::string, ContentLoader*> LoadersContainer;
+          typedef std::map<std::string, ContentLoader*> LoadersContainer;
           LoadersContainer mLoaders;
     };
 

--- a/components/files/configurationmanager.hpp
+++ b/components/files/configurationmanager.hpp
@@ -1,13 +1,7 @@
 #ifndef COMPONENTS_FILES_CONFIGURATIONMANAGER_HPP
 #define COMPONENTS_FILES_CONFIGURATIONMANAGER_HPP
 
-#if defined(_WIN32) && !defined(__MINGW32__)
-#include <boost/tr1/tr1/unordered_map>
-#elif defined HAVE_UNORDERED_MAP
-#include <unordered_map>
-#else
-#include <tr1/unordered_map>
-#endif
+#include <map>
 
 #include <boost/program_options.hpp>
 
@@ -52,11 +46,7 @@ struct ConfigurationManager
         typedef Files::FixedPath<> FixedPathType;
 
         typedef const boost::filesystem::path& (FixedPathType::*path_type_f)() const;
-    #if defined HAVE_UNORDERED_MAP
-        typedef std::unordered_map<std::string, path_type_f> TokensMappingContainer;
-    #else
-        typedef std::tr1::unordered_map<std::string, path_type_f> TokensMappingContainer;
-    #endif
+        typedef std::map<std::string, path_type_f> TokensMappingContainer;
 
         bool loadConfig(const boost::filesystem::path& path,
             boost::program_options::variables_map& variables,


### PR DESCRIPTION
This fixed #1 for me, allowing me to successfully build TES3MP with GCC 6.1.1 on Arch Linux.
Based on ["Don't use unordered_map" by scrawl on OpenMW](https://github.com/OpenMW/openmw/commit/fcbcc004a3e3817aed1a7fbafa3c2f03534b610c).

I believe ideally you gentlemen would prefer to more elegantly merge TES3MP with the most recent OpenMW changes, but merging this change might be useful for users with more recent GCC versions that would like a quick fix to this issue.

Thank you for your time.

PS: This is my first ever attempt at a patch and pull request, hope it is formulated according to standards :)
